### PR TITLE
Consolidate patches

### DIFF
--- a/Make.rules
+++ b/Make.rules
@@ -9,7 +9,13 @@ ifneq ($(lib_name),)
 CFLAGS_LIB ?= -fPIC
 CFLAGS += $(CFLAGS_LIB)
 
-libraries = $(lib_name).so $(lib_name).a
+ifneq ($(enable_static),no)
+libraries += $(lib_name).a
+endif
+
+ifneq ($(enable_shared),no)
+libraries += $(lib_name).so
+endif
 
 .PHONY: library
 
@@ -23,7 +29,7 @@ prerequisites = $(subst .o,.d,$(objects)) $(addsuffix .d,$(binaries))
 
 .PHONY: clean install
 
-ifeq ($(static),1)
+ifneq ($(enable_static),no)
 LDFLAGS += -static
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ DVB_API_MINOR := $(word 3, $(shell grep -m1 "DVB_API_VERSION_MINOR" $(VERSION_FI
 
 all clean install:
 	$(MAKE) -C lib $@
-	$(MAKE) -C test $@
 	$(MAKE) -C util $@
 
 update:

--- a/include/ca.h
+++ b/include/ca.h
@@ -24,6 +24,8 @@
 #ifndef _DVBCA_H_
 #define _DVBCA_H_
 
+#include <linux/version.h>
+
 /* slot interface types and info */
 
 typedef struct ca_slot_info {
@@ -85,6 +87,12 @@ typedef struct ca_pid {
 #define CA_GET_MSG        _IOR('o', 132, ca_msg_t)
 #define CA_SEND_MSG       _IOW('o', 133, ca_msg_t)
 #define CA_SET_DESCR      _IOW('o', 134, ca_descr_t)
+/* Removal of ca_pid_t and CA_GET_PID has been done since kernel 4.14
+ * so dont define CA_SET_PID as to match kernel header.
+ * https://github.com/torvalds/linux/commit/833ff5e7feda1a042b83e82208cef3d212ca0ef1
+ */
+#if LINUX_VERSION_CODE <= KERNEL_VERSION(4, 14, 0)
 #define CA_SET_PID        _IOW('o', 135, ca_pid_t)
+#endif
 
 #endif

--- a/lib/libdvbapi/dvbaudio.c
+++ b/lib/libdvbapi/dvbaudio.c
@@ -25,9 +25,12 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/ioctl.h>
-#include <linux/dvb/audio.h>
 #include <errno.h>
 #include "dvbaudio.h"
+
+#ifndef AUDIO_SET_BYPASS_MODE
+#define AUDIO_SET_BYPASS_MODE	_IO('o', 8)
+#endif
 
 int dvbaudio_open(int adapter, int audiodeviceid)
 {

--- a/test/test_av.c
+++ b/test/test_av.c
@@ -31,8 +31,6 @@
 #include <unistd.h>
 
 #include <linux/types.h>
-#include <linux/dvb/audio.h>
-#include <linux/dvb/video.h>
 
 int audioStop(int fd, char *arg)
 {

--- a/util/av7110_loadkeys/generate-keynames.sh
+++ b/util/av7110_loadkeys/generate-keynames.sh
@@ -18,7 +18,7 @@ echo "};" >> $1
 echo >> $1
 echo >> $1
 echo "static struct input_key_name key_name [] = {" >> $1
-for x in $(cat /usr/include/linux/input.h input_fake.h | \
+for x in $(cat ${CROSS_ROOT}/usr/include/linux/input.h input_fake.h | \
            egrep "#define[ \t]+KEY_" | grep -v KEY_MAX | \
            cut -f 1 | cut -f 2 -d " " | sort -u) ; do
     echo "        { \"$(echo $x | cut -b 5-)\", $x }," >> $1
@@ -26,7 +26,7 @@ done
 echo "};" >> $1
 echo >> $1
 echo "static struct input_key_name btn_name [] = {" >> $1
-for x in $(cat /usr/include/linux/input.h input_fake.h | \
+for x in $(cat ${CROSS_ROOT}/usr/include/linux/input.h input_fake.h | \
            egrep "#define[ \t]+BTN_" | \
            cut -f 1 | cut -f 2 -d " " | sort -u) ; do
      echo "        { \"$(echo $x | cut -b 5-)\", $x }," >> $1

--- a/util/dst-utils/dst_test.c
+++ b/util/dst-utils/dst_test.c
@@ -35,18 +35,7 @@
 #include <libdvben50221/en50221_app_tags.h>
 
 #define CA_NODE "/dev/dvb/adapter0/ca0"
-/*
- Quick hack around the removal of ca_pid_t and CA_GET_PID in recent kernels
-  https://github.com/torvalds/linux/commit/833ff5e7feda1a042b83e82208cef3d212ca0ef1
-*/
-#ifndef CA_SET_PID
-typedef struct ca_pid {
-	unsigned int pid;
-	int index;      /* -1 == disable*/
-} ca_pid_t;
-/* We should not be able to get it so a number that is unlikely to happen */
-#define CA_SET_PID 42424242
-#endif
+
 static int dst_comms(int cafd, uint32_t tag, uint32_t function, struct ca_msg *msg)
 {
 	if (tag) {

--- a/util/dst-utils/dst_test.c
+++ b/util/dst-utils/dst_test.c
@@ -111,6 +111,7 @@ static int dst_reset(int cafd)
 	return 0;
 }
 
+#if defined CA_SET_PID
 static int dst_set_pid(int cafd)
 {
 	if ((ioctl(cafd, CA_SET_PID)) < 0) {
@@ -120,6 +121,7 @@ static int dst_set_pid(int cafd)
 
 	return 0;
 }
+#endif
 
 static int dst_get_descr(int cafd)
 {
@@ -230,8 +232,12 @@ int main(int argc, char *argv[])
 				dst_reset(cafd);
 				break;
 			case 'p':
+#if defined CA_SET_PID
 				printf("%s: PID\n", __FUNCTION__);
 				dst_set_pid(cafd);
+#else
+				printf("%s: PID not supported\n", __FUNCTION__);
+#endif
 				break;
 			case 'g':
 				printf("%s: Get Desc\n", __FUNCTION__);

--- a/util/scan/Makefile
+++ b/util/scan/Makefile
@@ -14,7 +14,7 @@ inst_bin = $(binaries)
 
 removing = atsc_psip_section.c atsc_psip_section.h
 
-CPPFLAGS += -Wno-packed-bitfield-compat -D__KERNEL_STRICT_NAMES
+CPPFLAGS += -D__KERNEL_STRICT_NAMES
 
 .PHONY: all
 

--- a/util/scan/diseqc.c
+++ b/util/scan/diseqc.c
@@ -1,6 +1,6 @@
+#include <time.h>
 #include <linux/dvb/frontend.h>
 #include <sys/ioctl.h>
-#include <time.h>
 
 #include "scan.h"
 #include "diseqc.h"

--- a/util/szap/szap.c
+++ b/util/szap/szap.c
@@ -46,7 +46,6 @@
 
 #include <linux/dvb/frontend.h>
 #include <linux/dvb/dmx.h>
-#include <linux/dvb/audio.h>
 #include "lnb.h"
 #include "util.h"
 
@@ -55,6 +54,10 @@
 #endif
 #ifndef FALSE
 #define FALSE (1==0)
+#endif
+
+#ifndef AUDIO_SET_BYPASS_MODE
+#define AUDIO_SET_BYPASS_MODE  _IO('o', 8)
 #endif
 
 /* location of channel list file */


### PR DESCRIPTION
- Revert "Fix build with newer than 4.14 kernels."
- From buildroot
  - utils: fix build with kernel headers >= 4.14
  - Fix generate-keynames.sh script for cross-compilation
  - Fix compiler warning flags
  - Make.rules: Handle static/shared only build
  - Makefile: remove test
- From LibreELEC
  - reorder includes
  - remove deprecated dvb includes
- dont define CA_SET_PID for kernels >= 4.14 in local ca.h